### PR TITLE
Improve documentation and clarify modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
 # Anubis
 
-Anubis is a lightweight toolkit for designing and analysing A/B experiments.
-It grew from a research notebook and now provides a small set of well
-structured modules with documentation and live examples.
+Anubis is a lightweight toolkit for running A/B tests. It includes helpers for power analysis, statistical tests, stratified sampling and CUPED variance reduction. Example notebooks demonstrating usage live in the `notebooks/` folder.
+
+It grew from a research notebook and now provides a small set of well structured modules with documentation and live examples.
 
 ## Project structure
 
-- `src/anubis/` – library code organised by topic (preprocessing, power
-  calculations, hypothesis tests, stratification, CUPED and simulations).
-- `docs/` – Markdown guides explaining the purpose and formulas behind each
-  module.
+- `src/anubis/` – library code organised by topic (preprocessing, power calculations, hypothesis tests, stratification, CUPED and simulations).
+- `docs/` – Markdown guides explaining the purpose and formulas behind each module.
 - `notebooks/` – Jupyter examples showing how to use the library.
 
-Install the package in editable mode and explore the notebooks to see typical
-workflows.
+Install the package in editable mode and explore the notebooks to see typical workflows.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# anubis_ab
+# Anubis
+
+Anubis is a lightweight toolkit for designing and analysing A/B experiments.
+It grew from a research notebook and now provides a small set of well
+structured modules with documentation and live examples.
+
+## Project structure
+
+- `src/anubis/` – library code organised by topic (preprocessing, power
+  calculations, hypothesis tests, stratification, CUPED and simulations).
+- `docs/` – Markdown guides explaining the purpose and formulas behind each
+  module.
+- `notebooks/` – Jupyter examples showing how to use the library.
+
+Install the package in editable mode and explore the notebooks to see typical
+workflows.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,4 @@
+# Documentation
+
+This folder contains markdown files describing the purpose of each module in Anubis.
+Use them as quick references for the statistical background and recommended scenarios.

--- a/docs/cuped.md
+++ b/docs/cuped.md
@@ -1,0 +1,9 @@
+# CUPED
+
+CUPED (Controlled Pre-experiment Data) is a variance reduction method. It uses a pre-experiment metric correlated with the target metric to adjust the post-experiment measurements.
+
+* `get_cuped_adjusted` — returns adjusted series for the test and control groups using the classic formula:
+  `theta = cov(post, pre) / var(pre)`
+  `adjusted = post - theta * (pre - mean_pre)`
+
+Applying CUPED can significantly improve the sensitivity of an experiment when the correlation is high.

--- a/docs/power.md
+++ b/docs/power.md
@@ -1,0 +1,11 @@
+# Power analysis
+
+Functions used to plan experiment sizes.
+
+Key formulas:
+
+* `get_mde_mean` calculates minimal detectable effect for a mean: `MDE = std * sqrt((z_alpha+z_beta)^2 * (1/q0 + 1/q1) / N)`.
+* `estimate_sample_size` solves the reverse problem — how many observations are required for the chosen effect size.
+* `min_sample_size_nominal` and `min_sample_size_nominal_in_r` compute the required sample for a z-test on proportions.
+
+Use these helpers before running an experiment to ensure the test is adequately powered.

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -1,0 +1,9 @@
+# Preprocessing
+
+Utilities that help clean raw experiment data before running tests.
+
+* `remove_outlier` — trims observations outside selected percentiles. Useful when extreme values can distort the mean.
+* `remove_outlier_interquartil` — applies the 1.5×IQR rule to drop outliers.
+* `box_cox_transform` — Box–Cox transformation to approximate normality; return the transformed series and fitted lambda.
+
+These steps reduce noise and can make statistical tests more reliable.

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -1,0 +1,8 @@
+# Simulation
+
+Use simulations to understand the statistical properties of your testing pipeline.
+
+* `run_synthetic_experiments` — creates many random A/B splits to measure the distribution of p-values under a specified effect.
+* `print_estimated_errors` — summarises type I/II error rates from the simulations.
+
+These helpers are handy when validating experiment design or custom metrics.

--- a/docs/stratification.md
+++ b/docs/stratification.md
@@ -1,0 +1,6 @@
+# Stratification
+
+Tools for controlled sampling. Stratified samples help reduce variance when user behaviour differs across segments.
+
+* `get_quantiles` — creates quantile buckets used as strata.
+* `stratified_sample_rows` — allocate rows into a fixed number of cohorts preserving the share of each stratum.

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,0 +1,10 @@
+# Statistical tests
+
+Provides wrappers around common hypothesis tests.
+
+* `ab_test_bootstrap` — non-parametric bootstrap comparison. Works well with heavy-tailed metrics.
+* `ab_test_nonparametric` — Mann–Whitney U test for ordinal or non-normal data.
+* `ab_test_parametric_continuous` — two-sample t-test with automatic variance check.
+* `ab_test_parametric_nominal` — z-test for binary metrics (proportions).
+
+Each function returns the statistic, p-value and effect estimate so you can interpret experiment results.

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,4 @@
+Example notebooks demonstrating typical workflows.
+
+* `power_example.ipynb` — basic power analysis.
+* `tests_example.ipynb` — how to run statistical tests on toy data.

--- a/notebooks/power_example.ipynb
+++ b/notebooks/power_example.ipynb
@@ -1,0 +1,40 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Power analysis example\n",
+    "Demonstrates minimum sample size calculation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from anubis.power import min_sample_size_nominal\n",
+    "\n",
+    "baseline = 0.1\n",
+    "mde = 0.02\n",
+    "min_n = min_sample_size_nominal(baseline, mde)\n",
+    "print('required size:', min_n)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/tests_example.ipynb
+++ b/notebooks/tests_example.ipynb
@@ -1,0 +1,20 @@
+{
+ "cells": [
+  {"cell_type": "markdown", "metadata": {}, "source": ["# A/B test example"]},
+  {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from anubis.tests import ab_test_parametric_continuous\n",
+    "\n",
+    "a = pd.Series(np.random.normal(0,1,100))\n",
+    "b = pd.Series(np.random.normal(0.1,1,100))\n",
+    "print(ab_test_parametric_continuous(a,b))"
+  ]}
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "version": "3.x"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/anubis/README.md
+++ b/src/anubis/README.md
@@ -1,0 +1,10 @@
+The `anubis` package is split into several modules:
+
+- `preprocessing` – data cleaning utilities
+- `power` – power and sample size calculations
+- `tests` – statistical test wrappers
+- `stratification` – functions for building balanced cohorts
+- `cuped` – CUPED variance reduction
+- `simulation` – tools for running synthetic experiments
+
+Each module exposes documented functions. Refer to the markdown files in `../../docs` for further explanation.

--- a/src/anubis/__init__.py
+++ b/src/anubis/__init__.py
@@ -1,0 +1,28 @@
+"""Top level package for the Anubis toolkit.
+
+The library collects common utilities used when planning and analysing
+controlled experiments. Import submodules to access specific functionality:
+
+- :mod:`anubis.preprocessing` – data cleaning helpers.
+- :mod:`anubis.power` – power and sample size calculations.
+- :mod:`anubis.tests` – wrappers for statistical tests.
+- :mod:`anubis.stratification` – building balanced cohorts.
+- :mod:`anubis.cuped` – CUPED variance reduction implementation.
+- :mod:`anubis.simulation` – tools for running synthetic experiments.
+"""
+
+from . import preprocessing
+from . import power
+from . import tests
+from . import stratification
+from . import cuped
+from . import simulation
+
+__all__ = [
+    "preprocessing",
+    "power",
+    "tests",
+    "stratification",
+    "cuped",
+    "simulation",
+]

--- a/src/anubis/cuped.py
+++ b/src/anubis/cuped.py
@@ -1,0 +1,21 @@
+"""Implementation of the CUPED variance reduction technique.
+
+CUPED uses pre-experiment metrics correlated with the target metric to reduce
+variance and increase sensitivity of statistical tests.
+"""
+import numpy as np
+import pandas as pd
+
+
+def get_cuped_adjusted(A_before: list[float], B_before: list[float], A_after: list[float], B_after: list[float]):
+    """Return CUPED adjusted series for control and test groups.
+
+    ``theta`` is estimated as ``cov(post, pre) / var(pre)`` and the adjustment is
+    ``adj = post - theta * (pre - mean_pre)``.
+    """
+    cv = np.cov([A_after + B_after, A_before + B_before])
+    theta = cv[0, 1] / cv[1, 1]
+    mean_before = np.mean(A_before + B_before)
+    A_adj = [after - (before - mean_before) * theta for after, before in zip(A_after, A_before)]
+    B_adj = [after - (before - mean_before) * theta for after, before in zip(B_after, B_before)]
+    return pd.Series(A_adj), pd.Series(B_adj)

--- a/src/anubis/power.py
+++ b/src/anubis/power.py
@@ -1,0 +1,116 @@
+"""Functions for power analysis and sample size planning.
+
+Before running an experiment we often want to know how many observations we need
+or what effect size we can reliably detect. The formulas implemented here follow
+standard textbooks and are suitable for quick calculations during planning.
+"""
+from typing import Iterable
+import numpy as np
+import pandas as pd
+from scipy.stats import norm
+import scipy.stats as scs
+import statsmodels.stats.api as sms
+
+
+def get_mde_mean(data: pd.Series, test_size: float = 0.5, alpha: float = 0.05, power: float = 0.8) -> float:
+    """Return the minimum detectable effect for the sample mean.
+
+    Parameters
+    ----------
+    data : Series
+        Historical observations of the metric.
+    test_size : float
+        Share of users in the test group.
+    alpha : float
+        Significance level.
+    power : float
+        Desired test power.
+
+    Notes
+    -----
+    The calculation is based on the formula
+    ``MDE = std * sqrt((z_alpha + z_beta)^2 * (1/q0 + 1/q1) / N)`` where ``q0``
+    and ``q1`` are the control and test splits.
+    """
+    n_total = data.count()
+    std = data.std()
+    z_alpha = scs.norm.ppf(1 - alpha / 2)
+    z_beta = scs.norm.ppf(power)
+    q0, q1 = test_size, 1 - test_size
+    c = (z_alpha + z_beta) ** 2 * (1 / q0 + 1 / q1)
+    es = np.sqrt(c / n_total)
+    return std * es
+
+
+def get_mde_proportion(data: pd.Series, alpha: float = 0.05, power: float = 0.8) -> float:
+    """Minimum detectable effect for a binary metric.
+
+    Assumes a 50/50 split between control and test groups. Use it for
+    conversion-rate style metrics.
+    """
+    n = data.count()
+    sd = data.std()
+    s = np.sqrt((sd ** 2 / n) + (sd ** 2 / n))
+    m = norm.ppf(q=1 - alpha / 2) + norm.ppf(q=power)
+    return m * s
+
+
+def estimate_sample_size(effect_size: float, data: pd.Series, alpha: float = 0.05, power: float = 0.8) -> float:
+    """Required sample size to detect ``effect_size`` change in a mean metric."""
+    sd = data.std()
+    m = (norm.ppf(q=1 - alpha / 2) + norm.ppf(q=power)) ** 2
+    return 2 * m * sd ** 2 / effect_size ** 2
+
+
+def min_sample_size_nominal(bcr: float, mde: float, alpha: float = 0.05, power: float = 0.8) -> int:
+    """Sample size for a two-proportion z-test.
+
+    Parameters
+    ----------
+    bcr : float
+        Baseline conversion rate.
+    mde : float
+        Minimum detectable effect (absolute difference).
+    """
+    standard_norm = scs.norm(0, 1)
+    z_beta = standard_norm.ppf(power)
+    z_alpha = standard_norm.ppf(1 - alpha / 2)
+    pooled_prob = (bcr + bcr + mde) / 2
+    n = 2 * pooled_prob * (1 - pooled_prob) * (z_beta + z_alpha) ** 2 / mde ** 2
+    return int(round(n))
+
+
+def min_sample_size_nominal_in_r(bcr: float, mde: float, alpha: float = 0.05, power: float = 0.8) -> int:
+    """Replicate ``pwr.2p.test`` from R for convenience."""
+    prop = bcr + mde
+    effect_size = sms.proportion_effectsize(bcr, prop)
+    sample_size = sms.NormalIndPower().solve_power(effect_size, power=power, alpha=alpha, ratio=1)
+    return int(round(sample_size))
+
+
+def sample_power_difftest(d: float, s: float, power: float = 0.8, sig: float = 0.05) -> int:
+    """Sample size based on expected difference ``d`` and variance ``s``."""
+    z = norm.isf([sig / 2])
+    zp = -1 * norm.isf([power])
+    n = s * ((zp + z) ** 2) / (d ** 2)
+    return int(round(n[0]))
+
+
+def min_sample_size_continuous(X: Iterable[float], mde: float, alpha: float = 0.05, power: float = 0.8) -> float:
+    """Sample size estimate for a t-test on a continuous metric."""
+
+    def get_c(alpha: float, power: float) -> float:
+        data = [{"0.05": 7.85, "0.01": 11.68}, {"0.05": 10.51, "0.01": 14.88}]
+        df = pd.DataFrame(data, index=["0.8", "0.9"])
+        return df.loc[str(power), str(alpha)]
+
+    sd = np.std(X, ddof=1)
+    c = get_c(alpha, power)
+    return 1 + (2 * c) * ((sd / mde) ** 2)
+
+
+def min_sample_size_continuous_nonparametric(X: Iterable[float], mde: float, alpha: float = 0.05, power: float = 0.8) -> float:
+    """Sample size for a non-parametric alternative to the t-test."""
+    sd = np.std(X, ddof=1)
+    n = 1.15 * 2 * (sd ** 2) * ((scs.norm.ppf(1 - alpha / 2) + scs.norm.ppf(power)) ** 2) / (mde ** 2)
+    return n

--- a/src/anubis/preprocessing.py
+++ b/src/anubis/preprocessing.py
@@ -1,0 +1,50 @@
+"""Data preprocessing utilities.
+
+Cleaning extreme values or transforming metrics can stabilise variance and help
+statistical tests meet their assumptions. Typical use cases are preparing
+revenue or engagement metrics before an A/B experiment.
+"""
+from typing import Tuple
+import numpy as np
+import pandas as pd
+import scipy.stats as scs
+from scipy.special import inv_boxcox
+
+
+def remove_outlier(df: pd.DataFrame, column: str, low: float = 0.05, high: float = 0.95) -> pd.Index:
+    """Return index of observations within the ``[low, high]`` percentile range.
+
+    Cutting off both tails removes extreme values that could skew the mean. The
+    function returns the index so you can subset the original DataFrame.
+    """
+    quant_df = df.quantile([low, high])
+    mask = (df[column] > quant_df.loc[low, column]) & (df[column] < quant_df.loc[high, column])
+    return df[column].dropna()[mask].index
+
+
+def remove_outlier_interquartil(df: pd.DataFrame, column: str) -> pd.DataFrame:
+    """Drop rows outside ``[Q1-1.5*IQR, Q3+1.5*IQR]``.
+
+    This classic rule is robust to skewed distributions and works well for most
+    business metrics.
+    """
+    q1 = df[column].quantile(0.25)
+    q3 = df[column].quantile(0.75)
+    iqr = q3 - q1
+    fence_low = q1 - 1.5 * iqr
+    fence_high = q3 + 1.5 * iqr
+    return df[(df[column] > fence_low) & (df[column] < fence_high)]
+
+
+def box_cox_transform(x: pd.Series, lmbda: float | None = None) -> Tuple[pd.Series, float]:
+    """Apply a Box–Cox transformation.
+
+    The transform ``y = (x^lambda - 1) / lambda`` stabilises variance and can
+    make the distribution more normal. The fitted ``lambda`` is returned so the
+    inverse transform can later be applied.
+    """
+    if lmbda is None:
+        transformed, lmbda = scs.boxcox(x)
+    else:
+        transformed = inv_boxcox(x, lmbda)
+    return pd.Series(transformed, index=x.index), lmbda

--- a/src/anubis/simulation.py
+++ b/src/anubis/simulation.py
@@ -1,0 +1,36 @@
+"""Helpers for validating experiment methodology via simulation.
+
+Running many random splits gives intuition about expected p-value distributions
+and empirical error rates.
+"""
+import numpy as np
+from scipy import stats
+from .power import estimate_sample_size
+
+
+def run_synthetic_experiments(values, sample_size, effect=0, n_iter=10000):
+    """Run repeated random splits and collect p-values."""
+    pvalues = []
+    for _ in range(n_iter):
+        a, b = np.random.choice(values, size=(2, sample_size,), replace=False)
+        b = b + effect
+        pval = stats.ttest_ind(a, b).pvalue
+        pvalues.append(pval)
+    return np.array(pvalues)
+
+
+def estimate_ci_bernoulli(p: float, n: int, alpha: float = 0.05):
+    """Confidence interval for a Bernoulli proportion."""
+    t = stats.norm.ppf(1 - alpha / 2, loc=0, scale=1)
+    std_n = np.sqrt(p * (1 - p) / n)
+    return p - t * std_n, p + t * std_n
+
+
+def print_estimated_errors(pvalues_aa, pvalues_ab, alpha: float):
+    """Compute and display empirical type I and type II error rates."""
+    first = np.mean(pvalues_aa < alpha)
+    second = np.mean(pvalues_ab >= alpha)
+    ci_first = estimate_ci_bernoulli(first, len(pvalues_aa))
+    ci_second = estimate_ci_bernoulli(second, len(pvalues_ab))
+    print(f"error I = {first:0.4f}  CI=({ci_first[0]:0.4f}, {ci_first[1]:0.4f})")
+    print(f"error II = {second:0.4f} CI=({ci_second[0]:0.4f}, {ci_second[1]:0.4f})")

--- a/src/anubis/stratification.py
+++ b/src/anubis/stratification.py
@@ -1,0 +1,68 @@
+"""Helpers for creating balanced experiment cohorts.
+
+Stratification ensures that control and test groups contain a similar mix of
+user segments. This reduces variance and guards against imbalance when the
+population is heterogeneous.
+"""
+from __future__ import annotations
+import math
+import numpy as np
+import pandas as pd
+from sklearn.utils import shuffle
+
+
+def get_quantiles(data: pd.DataFrame, cols: list[str]):
+    """Return a copy of ``data`` with extra quantile columns.
+
+    These quantile buckets are often used as strata for controlled sampling.
+    """
+    temp = data.copy()
+    quantiles = temp.quantile(q=[0.2, 0.4, 0.6, 0.8]).to_dict()
+    cols_q = []
+
+    def quantile(x, p, d):
+        if x <= d[p][0.2]:
+            return 1
+        elif x <= d[p][0.4]:
+            return 2
+        elif x <= d[p][0.6]:
+            return 3
+        elif x <= d[p][0.8]:
+            return 4
+        else:
+            return 5
+
+    for c in cols:
+        cq = c + "_q"
+        temp[cq] = temp[c].apply(quantile, args=(c, quantiles))
+        cols_q.append(cq)
+    return temp, cols_q
+
+
+def stratified_sample_rows(data: pd.DataFrame, cols: list[str], id_col: str, n_cohorts: int, n_rows: int, rs: int | None = None):
+    """Create cohorts with roughly ``n_rows`` elements each.
+
+    The allocation preserves the share of each quantile combination. Use this
+    function when you want balanced groups for an A/B test and the overall
+    dataset is large.
+    """
+    experiment = pd.DataFrame(columns=list(data.columns))
+    unallocated = pd.DataFrame()
+    data = data.set_index(cols)
+    l_data = len(data)
+    for _, temp in data.groupby(level=cols):
+        temp.reset_index(inplace=True)
+        l_temp = len(temp)
+        m = math.ceil(n_rows * (l_temp / l_data))
+        if m * n_cohorts > l_temp:
+            continue
+        unall = temp.copy()
+        temp = temp.sample(n=m * n_cohorts, random_state=rs)
+        unall = unall[~unall[id_col].isin(temp[id_col])]
+        unallocated = pd.concat([unallocated, unall])
+        temp = shuffle(temp, random_state=rs)
+        df_split = np.array_split(temp, n_cohorts)
+        for i in range(n_cohorts):
+            df_split[i]["cohort"] = i + 1
+        experiment = pd.concat([experiment] + df_split)
+    return experiment, unallocated

--- a/src/anubis/tests.py
+++ b/src/anubis/tests.py
@@ -1,0 +1,74 @@
+"""Collection of statistical tests for analysing experiment results.
+
+The wrappers expose consistent return values and hide some of the parameter
+choices required when using the underlying scipy/statsmodels functions. They are
+not meant to replace full-fledged libraries but to capture common patterns used
+in A/B testing.
+"""
+from __future__ import annotations
+import numpy as np
+import pandas as pd
+import scipy.stats as scs
+import statsmodels.stats.api as sms
+import statsmodels.stats.proportion as ssp
+import bootstrapped.bootstrap as bs
+import bootstrapped.stats_functions as bs_stats
+import bootstrapped.compare_functions as bs_compare
+
+
+def ab_test_bootstrap(a: pd.Series, b: pd.Series, stat: str = "mean", compare_func: str = "difference", n_bootstraps: int = 1000, alpha: float = 0.05) -> tuple:
+    """Bootstrap comparison of two samples.
+
+    Useful when the metric distribution is heavy tailed or the standard
+    parametric assumptions do not hold. Returns the effect estimate, confidence
+    interval and a boolean flag of significance.
+    """
+    if stat not in ("median", "std", "sum", "mean"):
+        raise ValueError("stat must be one of 'median', 'std', 'sum', 'mean'")
+    if compare_func not in ("percent_change", "difference"):
+        raise ValueError("compare_func must be 'percent_change' or 'difference'")
+
+    stat_func = {
+        "median": bs_stats.median,
+        "std": bs_stats.std,
+        "sum": bs_stats.sum,
+        "mean": bs_stats.mean,
+    }[stat]
+
+    cmp = bs_compare.percent_change if compare_func == "percent_change" else bs_compare.difference
+
+    results = bs.bootstrap_ab(a.values, b.values, stat_func, cmp, alpha=alpha, iteration_batch_size=10, num_iterations=n_bootstraps)
+    is_sign = np.sign(results.lower_bound) == np.sign(results.upper_bound)
+    effect = results.value
+    ci = (results.lower_bound, results.upper_bound)
+    return effect, ci, is_sign
+
+
+def ab_test_nonparametric(a: pd.Series, b: pd.Series, alternative: str = "two-sided", alpha: float = 0.05) -> tuple:
+    """Mann–Whitney U test for independent samples."""
+    st, pval = scs.mannwhitneyu(a, b, alternative=alternative)
+    diff = a.median() - b.median()
+    is_sign = pval <= alpha
+    return st, pval, diff, is_sign
+
+
+def ab_test_parametric_continuous(a: pd.Series, b: pd.Series, alternative: str = "two-sided", alpha: float = 0.05) -> tuple:
+    """Two sample t-test with automatic variance check."""
+    stat_l, pval_l = scs.levene(a, b)
+    usevar = "pooled" if pval_l > alpha else "unequal"
+    st, pval, _ = sms.ttest_ind(a, b, alternative=alternative, usevar=usevar)
+    diff = a.mean() - b.mean()
+    ci = sms.CompareMeans.from_data(a, b).tconfint_diff(alternative=alternative, usevar=usevar)
+    is_sign = pval <= alpha
+    return st, pval, diff, ci, is_sign
+
+
+def ab_test_parametric_nominal(a: pd.Series, b: pd.Series, alternative: str = "two-sided", alpha: float = 0.05) -> tuple:
+    """Two sample z-test for proportions."""
+    size_a, size_b = a.count(), b.count()
+    success_a, success_b = a.sum(), b.sum()
+    z_stat, pval = ssp.proportions_ztest([success_a, success_b], nobs=[size_a, size_b], alternative=alternative)
+    ci = ssp.confint_proportions_2indep(success_a, size_a, success_b, size_b, alpha=alpha)
+    prop_diff = success_a / size_a - success_b / size_b
+    is_sign = pval <= alpha
+    return z_stat, pval, prop_diff, ci, is_sign


### PR DESCRIPTION
## Summary
- expand README with project structure
- create markdown docs for each module
- add README for notebooks and source package
- document modules and functions with detailed docstrings for statistical context

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846341cba88832e8645a638b8e8087e